### PR TITLE
Filter duplicate resolutions

### DIFF
--- a/Sources/BunnyStreamPlayer/Model/Video.swift
+++ b/Sources/BunnyStreamPlayer/Model/Video.swift
@@ -50,7 +50,7 @@ extension Video {
     var computedResolutions = [Video.Resolution.auto]
     let resolutionStrings = videoConfigResponse.availableResolutions.split(separator: ",")
     for resolutionLabel in resolutionStrings {
-      if let resolution = Video.Resolution(rawValue: String(resolutionLabel)) {
+      if let resolution = Video.Resolution(rawValue: String(resolutionLabel)), !computedResolutions.contains(resolution) {
         computedResolutions.append(resolution)
       }
     }

--- a/Sources/BunnyStreamPlayer/Model/VideoResolution.swift
+++ b/Sources/BunnyStreamPlayer/Model/VideoResolution.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 extension Video {
-  enum Resolution: String, Identifiable {
+  enum Resolution: String, Identifiable, Equatable {
     var id: Self {
       self
     }


### PR DESCRIPTION
As a precaution, filter out any duplicate resolutions manually.