### PR TITLE
Update Documentation workflow runner to macos-15

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build-and-deploy:
-    runs-on: macos-13
+    runs-on: macos-15
     
     steps:
     - name: Checkout Repository


### PR DESCRIPTION
macos-13 runners are deprecated and no longer supported by GitHub Actions.