### PR TITLE
Bugfix - Issue 31: Fix video controls touch targets and seek bar gesture handling

### DIFF
--- a/Sources/BunnyStreamPlayer/Controls/SeekBarView/SeekBarView.swift
+++ b/Sources/BunnyStreamPlayer/Controls/SeekBarView/SeekBarView.swift
@@ -44,12 +44,15 @@ struct SeekBarView: View {
     }
     .frame(height: UI.seekBarFrameHeight)
     .background(.gray.opacity(0.001))
-    .gesture(DragGesture(minimumDistance: .zero).onChanged { value in
+    .gesture(DragGesture(minimumDistance: 8).onChanged { value in
+        let isHorizontal = abs(value.translation.width) > abs(value.translation.height)
+        guard isHorizontal else { return }
       isDragging = true
       isDraggingOutside = true
       dragPosition = min(max(value.location.x, .zero), size.width)
     }
       .onEnded { _ in
+        guard isDragging else { return }
         isDragging = false
         isDraggingOutside = false
         updatePlayerPosition(for: size)

--- a/Sources/BunnyStreamPlayer/Controls/VideoPlayerControls.swift
+++ b/Sources/BunnyStreamPlayer/Controls/VideoPlayerControls.swift
@@ -72,7 +72,7 @@ extension VideoPlayerControls {
   func centerControlsView() -> some View {
     HStack {
       Spacer()
-      
+        
       Button(action: viewModel.skipBackward) {
         theme.images.seekBackward
           .resizable()
@@ -80,10 +80,12 @@ extension VideoPlayerControls {
           .frame(width: 30, height: 30)
           .foregroundColor(.white)
       }
+      .frame(minWidth: 44, minHeight: 44)
+      .contentShape(Rectangle())
       .shouldAddView(controlsToCheck: .rewind, in: videoPlayerConfig.controls)
-      
+
       Spacer()
-      
+
       Button(action: viewModel.togglePlayPause) {
         (viewModel.isPlaying ? theme.images.pause : theme.images.play)
           .resizable()
@@ -91,10 +93,12 @@ extension VideoPlayerControls {
           .frame(width: 40, height: 40)
           .foregroundColor(.white)
       }
+      .frame(minWidth: 44, minHeight: 44)
+      .contentShape(Rectangle())
       .shouldAddView(controlsToCheck: .play, in: videoPlayerConfig.controls)
-      
+
       Spacer()
-      
+
       Button(action: viewModel.skipForward) {
         theme.images.seekForward
           .resizable()
@@ -102,8 +106,10 @@ extension VideoPlayerControls {
           .frame(width: 30, height: 30)
           .foregroundColor(.white)
       }
+      .frame(minWidth: 44, minHeight: 44)
+      .contentShape(Rectangle())
       .shouldAddView(controlsToCheck: .fastForward, in: videoPlayerConfig.controls)
-      
+
       Spacer()
     }
   }
@@ -112,7 +118,7 @@ extension VideoPlayerControls {
     VStack {
       seekBarView()
         .shouldAddView(controlsToCheck: .progress, in: videoPlayerConfig.controls)
-      
+
       HStack {
         timeView()
         Spacer()
@@ -129,6 +135,7 @@ extension VideoPlayerControls {
       }
       .padding(.horizontal, 8)
     }
+    .padding(.bottom, 8)
   }
   
   func fullScreenButton() -> some View {
@@ -138,8 +145,10 @@ extension VideoPlayerControls {
         .frame(width: 30, height: 30)
         .foregroundColor(.white)
     }
+    .frame(minWidth: 44, minHeight: 44)
+    .contentShape(Rectangle())
   }
-  
+
   func volumeButton() -> some View {
     Button(action: viewModel.toggleMute) {
       (viewModel.isMuted ? theme.images.volumeOff : theme.images.volumeOn)
@@ -147,8 +156,10 @@ extension VideoPlayerControls {
         .frame(width: 30, height: 30)
         .foregroundColor(.white)
     }
+    .frame(minWidth: 44, minHeight: 44)
+    .contentShape(Rectangle())
   }
-  
+
   @ViewBuilder
   func optionsButton() -> some View {
     Button {
@@ -159,6 +170,8 @@ extension VideoPlayerControls {
         .frame(width: 30, height: 30)
         .foregroundColor(.white)
     }
+    .frame(minWidth: 44, minHeight: 44)
+    .contentShape(Rectangle())
   }
   
   @ViewBuilder
@@ -216,12 +229,13 @@ extension VideoPlayerControls {
         .frame(width: 30, height: 30)
         .foregroundColor(.white)
     }
+    .frame(minWidth: 44, minHeight: 44)
+    .contentShape(Rectangle())
   }
   
   func seekBarView() -> some View {
     SeekBarView(viewModel: viewModel.seekBarViewModel, isDraggingOutside: $viewModel.isDraggingSeekBar)
       .environment(\.videoPlayerConfig, videoPlayerConfig)
-      .padding(.bottom, -16)
   }
   
   func timeView() -> some View {


### PR DESCRIPTION
[Issue 31](https://github.com/BunnyWay/bunny-stream-ios/issues/31)

  **Fix video controls touch targets and seek bar gesture handling**
  
  Addresses usability issues reported for larger screen devices (iPad) where controls were difficult to interact with and the seek bar conflicted with system gestures.

  Changes

  Larger touch targets for all control buttons (VideoPlayerControls.swift)

  All player buttons (play/pause, rewind, fast-forward, fullscreen, volume, settings, captions) had a visual size of 30–40 pt with no expanded hit area. On iPad this required very precise tapping to activate them. Each button now has a minimum
  tappable area of 44×44 pt via .frame(minWidth: 44, minHeight: 44) and .contentShape(Rectangle()), in line with Apple's Human Interface Guidelines. The visual appearance is unchanged.

  Bottom controls lifted away from the screen edge (VideoPlayerControls.swift)

  The bottom controls section had a negative padding of -16 pt applied to the seek bar, pushing it towards the very bottom of the screen. On devices with a home indicator (iPhone X and later, all iPads with Face ID) this caused the seek bar to
  overlap the system swipe-up area. The negative padding has been removed and a padding(.bottom, 8) has been added to the entire bottom section to ensure controls are always reachable.

  Seek bar now ignores vertical gestures (SeekBarView.swift)

  The seek bar was using DragGesture(minimumDistance: .zero), which captured all touch input including vertical swipes — making it impossible to perform the iOS system "minimize" gesture without accidentally seeking. The gesture now:
  - Requires a minimum drag distance of 8 pt before activating, preventing unintentional seeks from taps
  - Checks the drag direction on each update and ignores gestures that are more vertical than horizontal
  - Guards onEnded to skip the seek update if the drag was never actually activated
  
  This matches the behaviour of the native iOS AVPlayerViewController seek bar.

  Files changed

  - Sources/BunnyStreamPlayer/Controls/VideoPlayerControls.swift
  - Sources/BunnyStreamPlayer/Controls/SeekBarView/SeekBarView.swift