### PR TITLE
Fix #32: remove duplicate VideoPlayerError nested enum from VideoPlayerConfigLoader

### DIFF
--- a/Sources/BunnyStreamPlayer/Player/Loaders/VideoPlayerConfigLoader.swift
+++ b/Sources/BunnyStreamPlayer/Player/Loaders/VideoPlayerConfigLoader.swift
@@ -60,13 +60,3 @@ public struct VideoPlayerConfigLoader {
     try await load(libraryId: libraryId, videoId: videoId, token: token, expires: expires).thumbnailUrl
   }
 }
-
-
-extension VideoPlayerConfigLoader {
-  enum VideoPlayerError: Error {
-    case unauthorized
-    case notFound
-    case internalServerError
-    case unknownError
-  }
-}


### PR DESCRIPTION
`VideoPlayerConfigLoader` defined a nested `VideoPlayerError` enum that shadowed the module-level
  `BunnyStreamPlayer.VideoPlayerError`:

  ```swift
  // Module-level — Sources/BunnyStreamPlayer/Model/VideoPlayerError.swift
  enum VideoPlayerError: Error { ... }

  // Nested (duplicate) — VideoPlayerConfigLoader.swift
  extension VideoPlayerConfigLoader {
    enum VideoPlayerError: Error { ... } // ← shadows the module-level type
  }

  Inside VideoPlayerConfigLoader.load(), the unqualified VideoPlayerError resolved to the nested type, so all thrown errors were
  instances of VideoPlayerConfigLoader.VideoPlayerError.

  Back in BunnyStreamPlayer.loadVideo(), the typed catch resolved VideoPlayerError to the module-level type — a different,
  non-interchangeable Swift type. The cast silently failed at runtime, every error fell through to the generic catch, and loadingState
  was always set to .failed instead of .loaderFailed(error).
  
  As a result, errorView(for:) was never reached. Users always saw a generic reload button regardless of whether the failure was a 401
  Unauthorized, 404 Not Found, or a network error.

  Fix

  Removed the duplicate nested VideoPlayerError enum from VideoPlayerConfigLoader. All four of its cases (unauthorized, notFound,
  internalServerError, unknownError) already exist in the module-level enum, so no call sites required changes.

  Test plan

  - [ ] Load a video with an invalid/expired token → errorView(for: .unauthorized) is shown instead of the reload button
  - [ ] Load a video with a non-existent video ID → errorView(for: .notFound) is shown
  - [ ] Load a valid public video → playback works normally
  - [ ] Build succeeds with no new errors
